### PR TITLE
Use stdlib sort

### DIFF
--- a/dsm2/src/gtm_core/CMakeLists.txt
+++ b/dsm2/src/gtm_core/CMakeLists.txt
@@ -6,5 +6,5 @@ file(GLOB SOURCES *.F90 *.f90)
 target_sources(gtm_core PRIVATE ${SOURCES})
 
 target_include_directories(gtm_core PUBLIC ${HDF5_Fortran_INCLUDE_DIRS})
-target_link_libraries(gtm_core PUBLIC common ${HDF5_LIBRARIES})
+target_link_libraries(gtm_core PUBLIC common ${HDF5_LIBRARIES} fortran_stdlib::fortran_stdlib)
 add_dependencies(gtm_core common)

--- a/dsm2/src/gtm_core/utils.f90
+++ b/dsm2/src/gtm_core/utils.f90
@@ -171,21 +171,28 @@ module utils
                            n_nonzero,  &
                            n_matrix)
         use constants
+        use stdlib_sorting, only: sort_index
         implicit none
+
+        integer, intent(out) :: ap(:)
+        integer, intent(out) :: ai(:)
+        integer, intent(in) :: row(:)
+        integer, intent(in) :: col(:)
+        integer, intent(in) :: rcindex(:)
         integer, intent(in) :: n_nonzero
         integer, intent(in) :: n_matrix
-        integer, intent(in) :: row(n_nonzero)
-        integer, intent(in) :: col(n_nonzero)
-        integer, intent(in) :: rcindex(n_nonzero)
-        integer, intent(out) :: ai(n_nonzero)
-        integer, intent(out) :: ap(n_matrix+1)
-        integer :: rci(n_nonzero)
-        integer :: ro(n_nonzero)
+
+        ! local variables
+        integer, allocatable :: rci(:)
+        integer, allocatable :: ro(:)
         integer :: i, j, k
+
+        allocate(ro(n_nonzero))
+        allocate(rci(n_nonzero))
 
         ro = row
         rci = rcindex
-        call QsortCI(ro, rci)
+        call sort_index(ro, rci)
         ai = LARGEINT
         ap(1) = 0
         k = 0
@@ -199,6 +206,8 @@ module utils
                 end if
             end do
         end do
+        deallocate(ro)
+        deallocate(rci)
         return
     end subroutine
 


### PR DESCRIPTION
GTM uses its own recursive implementation of the quick sort, `QsortCI.` This recursive call may cause stack overflow by too many recursions. To address the issue, stdlib sort_index is swapped in place of QsortCI.

DSM2-1374