### PR TITLE
Manage external flows at channel ends

### DIFF
--- a/dsm2/src/gtm/boundary_advection_network.f90
+++ b/dsm2/src/gtm/boundary_advection_network.f90
@@ -470,16 +470,18 @@ module boundary_advection_network
         use constants
         use error_handling
         use gtm_vars, only: n_node, dsm2_network, dsm2_network_extra, n_bfbs, bfbs, &
-                                    n_sediment, n_sediment_bc, sediment, sediment_bc, n_node_ts
+                            n_sediment, n_sediment_bc, sediment, sediment_bc, n_node_ts, &
+                            qext, n_qext
         use common_gtm_vars, only: n_inputpaths, pathinput
-        use state_variables_network, only : node_conc, conc_stip
+        use state_variables_network, only : node_conc, conc_stip, qext_flow
         implicit none
         integer, intent(in)  :: ncell                            !< Number of cells
         integer, intent(in)  :: nvar                             !< Number of variables
         integer, intent(in)  :: tstp
         real(gtm_real), intent(inout) :: conc_lo(ncell,nvar)     !< Concentration extrapolated to lo face
         real(gtm_real), intent(inout) :: conc_hi(ncell,nvar)     !< Concentration extrapolated to hi face
-        integer :: i, j, k, s, st, icell, inode
+        integer :: i, j, k, s, st, icell, inode, qext_path_id, ivar, iqext, nq
+        real(gtm_real) :: flow_sum, qext_fl, flux, conc_ext
 
         do i = 1, n_bfbs
             inode = bfbs(i)%i_node
@@ -513,6 +515,37 @@ module boundary_advection_network
                         end do
                 end if
             end do
+        end do
+
+        ! Handle external flows like a boundary condition.
+        do iqext = 1, n_qext
+            inode = qext(iqext)%attach_obj_no
+            if (inode .le. 0) cycle
+            ! FIXME The block below can be factored out. A similar code block exists in `bc_advection_flux_network`.
+            ! Here we want to set the concentration value with the
+            ! external flows at dead-end (boundary) nodes by setting
+            nq = dsm2_network_extra(inode)%n_qext
+            if (nq .gt. 0) then
+                icell = dsm2_network(inode)%cell_no(1)
+                do ivar = 1, nvar
+                    flow_sum = zero
+                    flux = zero
+                    do k = 1, nq
+                        qext_fl = qext_flow(dsm2_network_extra(inode)%qext_no(k))
+                        if (qext_fl .gt. zero) then
+                            flow_sum = flow_sum + qext_fl
+                            qext_path_id = dsm2_network_extra(inode)%qext_path(k,ivar)
+                            if (qext_path_id .ne. 0) then
+                                conc_ext = pathinput(qext_path_id)%value
+                                flux = flux + qext_fl * conc_ext
+                            end if
+                        end if
+                    end do
+                    if (flow_sum .gt. zero) then
+                        conc_stip(icell,ivar) = flux / flow_sum
+                    end if
+                end do
+            end if
         end do
 
         !> Assign node concentration to the upstream boundaries that no node concentration is given.

--- a/dsm2/src/gtm/boundary_advection_network.f90
+++ b/dsm2/src/gtm/boundary_advection_network.f90
@@ -198,7 +198,7 @@ module boundary_advection_network
         !--- args
         integer,intent(in)  :: ncell                            !< Number of cells
         integer,intent(in)  :: nvar                             !< Number of variables
-        integer,intent(in)  :: tstp                             !< Time step
+        integer,intent(in)  :: tstp
         real(gtm_real),intent(inout) :: flux_lo(ncell,nvar)     !< Flux on lo side of cell, time centered
         real(gtm_real),intent(inout) :: flux_hi(ncell,nvar)     !< Flux on hi side of cell, time centered
         real(gtm_real),intent(out) :: sed_percent(n_node,n_qext,nvar)!<percentages of compositions at boundaries  & 10 is the maximum number of
@@ -344,92 +344,93 @@ module boundary_advection_network
                 end if
             end if
             ! adjust flux for junctions
-            flow_tmp = zero
-            mass_tmp(ivar) = zero
-            conc_tmp(ivar) = zero
-            conc_tmp0(ivar) = zero
-            flux_in = zero
-            do j = 1, dsm2_network(i)%n_conn_cell     ! counting flow into the junctions
-                icell = dsm2_network(i)%cell_no(j)
-                if (dsm2_network(i)%up_down(j).eq.0 .and. flow_hi(icell).gt.zero) then     !cell at downstream of junction
-                    flux_in = flux_in + conc_hi(icell,ivar)*flow_hi(icell)
-                    flow_tmp = flow_tmp + flow_hi(icell)
-                elseif (dsm2_network(i)%up_down(j).eq.1 .and. flow_lo(icell).lt.zero) then !cell at upstream of junction
-                    flux_in = flux_in - conc_lo(icell,ivar)*flow_lo(icell)
-                    flow_tmp = flow_tmp - flow_lo(icell)
-                endif
-            end do
-
-            ! add external flows
-            if ((dsm2_network(i)%boundary_no.eq.0).and.(dsm2_network_extra(i)%n_qext.gt.0)) then
-                ! loop through external flows
-                do j = 1, dsm2_network_extra(i)%n_qext
-                    qext_fl = qext_flow(dsm2_network_extra(i)%qext_no(j))
-                    ! If drain and if there are associated data to it
-                    qext_path_id = dsm2_network_extra(i)%qext_path(j,ivar)
-                    if (qext_fl > 0) then ! drain
-                        flow_tmp = flow_tmp + qext_fl
-                        if (qext_path_id /= 0) then
-                            conc_ext = pathinput(qext_path_id)%value
-                            ! If the associated data is SSC,
-                            if (trim(pathinput(qext_path_id)%variable).eq.'ssc') then
-                                ! Loop through all the sediment classes
-                                do st = 1, n_sediment
-                                    conc_ext = pathinput(qext_path_id)%value &
-                                        * sed_percent(i,j,nvar-n_sediment+st) * 0.01d0
-                                end do
-                            end if
-                            flux_in = flux_in + conc_ext * qext_fl
-                        else !drain but node concentration is absent
-                            flux_in = flux_in + conc_ext * qext_fl
-                            write(*,*) "WARNING: No node concentration is given for DSM2 Node No. !!",dsm2_network(i)%dsm2_node_no
-                        end if
-                    end if
-                end do
-            end if
-
-            ! add reservoir flows
-            if (dsm2_network_extra(i)%reservoir_no.ne.0) then
-                reservoir_id = dsm2_network_extra(i)%reservoir_no
-                resv_conn_id = dsm2_network_extra(i)%resv_conn_no
-                vol(reservoir_id) = vol(reservoir_id) - resv_flow(resv_conn_id)*dt
-                ! Flow going out of the reservoir
-                if (resv_flow(resv_conn_id).gt.zero) then
-                    mass_resv(reservoir_id,ivar) = mass_resv(reservoir_id,ivar) - resv_flow(resv_conn_id)*dt*conc_resv_prev(reservoir_id,ivar)
-                    flux_in = flux_in + conc_resv_prev(reservoir_id,ivar)*resv_flow(resv_conn_id)
-                    flow_tmp = flow_tmp + resv_flow(resv_conn_id)
-                end if
-            end if
-
-            if (flow_tmp < 0.01) then
+            if (dsm2_network(i)%junction_no .gt. 0) then
+                flow_tmp = zero
+                mass_tmp(ivar) = zero
                 conc_tmp(ivar) = zero
-            else
-                conc_tmp(ivar) = flux_in / flow_tmp
-            end if
-            ! assign average concentration to downstream cell faces
-            do j = 1, dsm2_network(i)%n_conn_cell
-                icell = dsm2_network(i)%cell_no(j)
-                prev_conc_stip(icell,ivar) = conc_stip(icell,ivar)
-                conc_stip(icell,ivar) = LARGEREAL
-                if ((dsm2_network(i)%up_down(j).eq.0) .and. (flow_hi(icell).le.zero)) then  !cell at updstream of junction and flow away from junction
-                    flux_hi(icell,ivar) = conc_tmp(ivar)*flow_hi(icell)
-                    conc_stip(icell,ivar) = conc_tmp(ivar)
-                elseif ((dsm2_network(i)%up_down(j).eq.1) .and. (flow_lo(icell).ge.zero)) then !cell at downdstream of junction
-                    flux_lo(icell,ivar) = conc_tmp(ivar)*flow_lo(icell)
-                    conc_stip(icell,ivar) = conc_tmp(ivar)
-                endif
-            end do
-            ! assign the average concentration to the reservoir
-            if (dsm2_network_extra(i)%reservoir_no.ne.0) then
-                reservoir_id = dsm2_network_extra(i)%reservoir_no
-                resv_conn_id = dsm2_network_extra(i)%resv_conn_no
-                ! Flow going into the reservoir
-                if (resv_flow(resv_conn_id) < 0.0) then
-                    mass_resv(reservoir_id,ivar) = mass_resv(reservoir_id,ivar) - resv_flow(resv_conn_id)*dt*conc_tmp(ivar)
+                conc_tmp0(ivar) = zero
+                flux_in = zero
+                do j = 1, dsm2_network(i)%n_conn_cell     ! counting flow into the junctions
+                    icell = dsm2_network(i)%cell_no(j)
+                    if (dsm2_network(i)%up_down(j).eq.0 .and. flow_hi(icell).gt.zero) then     !cell at updstream of junction
+                        flux_in = flux_in + conc_hi(icell,ivar)*flow_hi(icell)
+                        flow_tmp = flow_tmp + flow_hi(icell)
+                    elseif (dsm2_network(i)%up_down(j).eq.1 .and. flow_lo(icell).lt.zero) then !cell at downdstream of junction
+                        flux_in = flux_in - conc_lo(icell,ivar)*flow_lo(icell)
+                        flow_tmp = flow_tmp - flow_lo(icell)
+                    endif
+                end do
+
+                ! add external flows
+                if ((dsm2_network(i)%boundary_no.eq.0).and.(dsm2_network_extra(i)%n_qext.gt.0)) then
+                    ! loop through external flows
+                    do j = 1, dsm2_network_extra(i)%n_qext
+                        qext_fl = qext_flow(dsm2_network_extra(i)%qext_no(j))
+                        ! If drain and if there are associated data to it
+                        qext_path_id = dsm2_network_extra(i)%qext_path(j,ivar)
+                        if (qext_fl > 0) then ! drain
+                            flow_tmp = flow_tmp + qext_fl
+                            if (qext_path_id /= 0) then
+                                conc_ext = pathinput(qext_path_id)%value
+                                ! If the associated data is SSC,
+                                if (trim(pathinput(qext_path_id)%variable).eq.'ssc') then
+                                    ! Loop through all the sediment classes
+                                    do st = 1, n_sediment
+                                        conc_ext = pathinput(qext_path_id)%value &
+                                            * sed_percent(i,j,nvar-n_sediment+st) * 0.01d0
+                                    end do
+                                end if
+                                flux_in = flux_in + conc_ext * qext_fl
+                            else !drain but node concentration is absent
+                                flux_in = flux_in + conc_ext * qext_fl
+                                write(*,*) "WARNING: No node concentration is given for DSM2 Node No. !!",dsm2_network(i)%dsm2_node_no
+                            end if
+                        end if
+                    end do
+                end if
+
+                ! add reservoir flows
+                if (dsm2_network_extra(i)%reservoir_no.ne.0) then
+                    reservoir_id = dsm2_network_extra(i)%reservoir_no
+                    resv_conn_id = dsm2_network_extra(i)%resv_conn_no
+                    vol(reservoir_id) = vol(reservoir_id) - resv_flow(resv_conn_id)*dt
+                    ! Flow going out of the reservoir
+                    if (resv_flow(resv_conn_id).gt.zero) then
+                        mass_resv(reservoir_id,ivar) = mass_resv(reservoir_id,ivar) - resv_flow(resv_conn_id)*dt*conc_resv_prev(reservoir_id,ivar)
+                        flux_in = flux_in + conc_resv_prev(reservoir_id,ivar)*resv_flow(resv_conn_id)
+                        flow_tmp = flow_tmp + resv_flow(resv_conn_id)
+                    end if
+                end if
+
+                if (flow_tmp < 0.01) then
+                    conc_tmp(ivar) = zero
+                else
+                    conc_tmp(ivar) = flux_in / flow_tmp
+                end if
+                ! assign average concentration to downstream cell faces
+                do j = 1, dsm2_network(i)%n_conn_cell
+                    icell = dsm2_network(i)%cell_no(j)
+                    prev_conc_stip(icell,ivar) = conc_stip(icell,ivar)
+                    conc_stip(icell,ivar) = LARGEREAL
+                    if ((dsm2_network(i)%up_down(j).eq.0) .and. (flow_hi(icell).le.zero)) then  !cell at updstream of junction and flow away from junction
+                        flux_hi(icell,ivar) = conc_tmp(ivar)*flow_hi(icell)
+                        conc_stip(icell,ivar) = conc_tmp(ivar)
+                    elseif ((dsm2_network(i)%up_down(j).eq.1) .and. (flow_lo(icell).ge.zero)) then !cell at downdstream of junction
+                        flux_lo(icell,ivar) = conc_tmp(ivar)*flow_lo(icell)
+                        conc_stip(icell,ivar) = conc_tmp(ivar)
+                    endif
+                end do
+                ! assign the average concentration to the reservoir
+                if (dsm2_network_extra(i)%reservoir_no.ne.0) then
+                    reservoir_id = dsm2_network_extra(i)%reservoir_no
+                    resv_conn_id = dsm2_network_extra(i)%resv_conn_no
+                    ! Flow going into the reservoir
+                    if (resv_flow(resv_conn_id) < 0.0) then
+                        mass_resv(reservoir_id,ivar) = mass_resv(reservoir_id,ivar) - resv_flow(resv_conn_id)*dt*conc_tmp(ivar)
+                    end if
                 end if
             end if
-
-        end do ! do through all nodes
+        end do
 
         do i = 1, n_resv
             if (resv_geom(i)%n_qext > 0) then

--- a/dsm2/src/gtm/boundary_advection_network.f90
+++ b/dsm2/src/gtm/boundary_advection_network.f90
@@ -353,10 +353,14 @@ module boundary_advection_network
                 do j = 1, dsm2_network(i)%n_conn_cell     ! counting flow into the junctions
                     icell = dsm2_network(i)%cell_no(j)
                     if (dsm2_network(i)%up_down(j).eq.0 .and. flow_hi(icell).gt.zero) then     !cell at updstream of junction
-                        flux_in = flux_in + conc_hi(icell,ivar)*flow_hi(icell)
+                        if (conc_hi(icell,ivar) .gt. zero) then
+                            flux_in = flux_in + conc_hi(icell, ivar) * flow_hi(icell)
+                        end if
                         flow_tmp = flow_tmp + flow_hi(icell)
                     elseif (dsm2_network(i)%up_down(j).eq.1 .and. flow_lo(icell).lt.zero) then !cell at downdstream of junction
-                        flux_in = flux_in - conc_lo(icell,ivar)*flow_lo(icell)
+                        if (conc_lo(icell,ivar) .gt. zero) then
+                            flux_in = flux_in - conc_lo(icell, ivar) * flow_lo(icell)
+                        end if
                         flow_tmp = flow_tmp - flow_lo(icell)
                     endif
                 end do


### PR DESCRIPTION
The external flows such as diversions in GTM is not processed correctly. Those external flows can be modeled like a boundary condition.