### PR TITLE
Fix summation bug for concentration and clean up transfer-related implementations

### DIFF
--- a/dsm2/src/gtm/boundary_advection_network.f90
+++ b/dsm2/src/gtm/boundary_advection_network.f90
@@ -196,7 +196,8 @@ module boundary_advection_network
         use gtm_vars, only: n_node, dsm2_network
         use common_gtm_vars, only: pathinput
         implicit none
-        integer,intent(in)  :: nvar, ivar
+        integer,intent(in)  :: nvar                                     !< Number of variables
+        integer,intent(in)  :: ivar                                     !< variable index
         real(gtm_real),intent(out) :: sed_percent(n_node,n_qext,nvar)!<percentages of compositions at boundaries  & 10 is the maximum number of
                                                                                          !external flows        !<TODO: make array dimensions effective
         integer :: i, j, s, st
@@ -365,7 +366,8 @@ module boundary_advection_network
         real(gtm_real),intent(in)    :: flow_hi(ncell)          !< Flow on hi side of cells centered in time
         real(gtm_real),intent(in)    :: conc_lo(ncell,nvar)     !< Concentration extrapolated to lo face
         real(gtm_real),intent(in)    :: conc_hi(ncell,nvar)     !< Concentration extrapolated to hi face
-        real(gtm_real),intent(inout) :: flow_tmp(n_node), flux_in(n_node)
+        real(gtm_real),intent(inout) :: flow_tmp(n_node)        !< Temporary flow array to calculate junction concentration
+        real(gtm_real),intent(inout) :: flux_in(n_node)         !< Flux into the junctions
         integer :: i, j, icell
 
         do i = 1, n_node
@@ -396,7 +398,8 @@ module boundary_advection_network
         implicit none
         integer,intent(in)  :: nvar                             !< Number of variables
         integer,intent(in)  :: ivar                             !< variable index
-        real(gtm_real),intent(inout) :: flow_tmp(n_node), flux_in(n_node)
+        real(gtm_real),intent(inout) :: flow_tmp(n_node)        !< Temporary flow array to calculate junction concentration
+        real(gtm_real),intent(inout) :: flux_in(n_node)         !< Flux into the junctions
         real(gtm_real),intent(in) :: sed_percent(n_node,n_qext,nvar)!<percentages of compositions at boundaries  & 10 is the maximum number of
                                                                                          !external flows        !<TODO: make array dimensions effective
         real(gtm_real) :: qext_fl
@@ -448,9 +451,10 @@ module boundary_advection_network
         integer,intent(in)  :: nvar                             !< Number of variables
         integer,intent(in)  :: ivar                             !< variable index
         real(gtm_real),intent(in)    :: dt                      !< Time step
-        real(gtm_real),intent(inout) :: flow_tmp(n_node), flux_in(n_node)
-        real(gtm_real),intent(inout) :: vol(n_resv)
-        real(gtm_real),intent(inout) :: mass_resv(n_resv,nvar)
+        real(gtm_real),intent(inout) :: flow_tmp(n_node)        !< Temporary flow array to calculate junction concentration
+        real(gtm_real),intent(inout) :: flux_in(n_node)         !< Flux into the junctions
+        real(gtm_real),intent(inout) :: vol(n_resv)             !< Volume of the reservoirs
+        real(gtm_real),intent(inout) :: mass_resv(n_resv,nvar)  !< Mass in the reservoirs
         integer :: i
         integer :: reservoir_id, resv_conn_id
 
@@ -479,7 +483,7 @@ module boundary_advection_network
         use state_variables_network, only : qext_flow, conc_qext
         use common_gtm_vars, only: pathinput
         implicit none
-        real(gtm_real),intent(inout) :: conc_tmp(n_node, nvar)
+        real(gtm_real),intent(inout) :: conc_tmp(n_node, nvar)  !< Concentration at each node
         integer,intent(in)  :: nvar                             !< Number of variables
         integer,intent(in)  :: ivar                             !< variable index
         real(gtm_real) :: conc_ext, qext_fl
@@ -519,10 +523,14 @@ module boundary_advection_network
         use gtm_vars, only : n_node, dsm2_network, dsm2_network_extra, n_qext
         use state_variables_network, only : conc_stip, prev_conc_stip
         implicit none
-        real(gtm_real),intent(inout) :: flux_lo(ncell,nvar), flux_hi(ncell,nvar)
-        real(gtm_real),intent(inout) :: conc_tmp(n_node, nvar)
-        real(gtm_real),intent(in) :: flow_lo(ncell), flow_hi(ncell)
-        integer, intent(in) :: ncell, nvar, ivar
+        real(gtm_real),intent(inout) :: flux_lo(ncell,nvar)             !< Flux on lo side of cell, time centered
+        real(gtm_real),intent(inout) :: flux_hi(ncell,nvar)             !< Flux on hi side of cell, time centered
+        real(gtm_real),intent(inout) :: conc_tmp(n_node, nvar)          !< Concentration at each node
+        real(gtm_real),intent(in) :: flow_lo(ncell)                     !< Flow on lo side of cells centered in time
+        real(gtm_real),intent(in) :: flow_hi(ncell)                     !< Flow on hi side of cells centered in time
+        integer, intent(in) :: ncell                                    !< Number of cells
+        integer, intent(in) :: nvar                                     !< Number of variables
+        integer, intent(in) :: ivar                                     !< variable index
         integer :: i, j, icell
         do i = 1, n_node
             if (dsm2_network(i)%junction_no .eq. 0) cycle
@@ -555,9 +563,9 @@ module boundary_advection_network
         integer,intent(in)  :: ivar                             !< variable index
         integer,intent(in)  :: use_previous_ts_val              !< whether to use previous time step values
         real(gtm_real),intent(in)    :: dt                      !< Time step
-        real(gtm_real),intent(inout) :: conc_tmp(n_node, nvar)
-        real(gtm_real),intent(inout) :: vol(n_resv)
-        real(gtm_real),intent(inout) :: mass_resv(n_resv,nvar)
+        real(gtm_real),intent(inout) :: conc_tmp(n_node, nvar)  !< Concentration at each node
+        real(gtm_real),intent(inout) :: vol(n_resv)             !< Volume of the reservoirs
+        real(gtm_real),intent(inout) :: mass_resv(n_resv,nvar)  !< Mass in the reservoirs
         integer :: i,j
         integer :: reservoir_id, resv_conn_id
 
@@ -680,7 +688,7 @@ module boundary_advection_network
         !--- args
         integer,intent(in)  :: ncell                            !< Number of cells
         integer,intent(in)  :: nvar                             !< Number of variables
-        integer,intent(in)  :: tstp
+        integer,intent(in)  :: tstp                             !< Time step index
         real(gtm_real),intent(inout) :: flux_lo(ncell,nvar)     !< Flux on lo side of cell, time centered
         real(gtm_real),intent(inout) :: flux_hi(ncell,nvar)     !< Flux on hi side of cell, time centered
         real(gtm_real),intent(out) :: sed_percent(n_node,n_qext,nvar)!<percentages of compositions at boundaries  & 10 is the maximum number of

--- a/dsm2/src/gtm/boundary_advection_network.f90
+++ b/dsm2/src/gtm/boundary_advection_network.f90
@@ -698,12 +698,13 @@ module boundary_advection_network
         real(gtm_real) :: mass_resv(n_resv,nvar)        
         integer :: i,ivar
 
-        ! initialize
-        flow_tmp(:) = zero
-        conc_tmp(:,:) = zero
-        flux_in(:) = zero
-
         do ivar = 1, nvar
+
+            ! initialize
+            conc_tmp(:,ivar) = zero
+            flow_tmp(:) = zero
+            flux_in(:) = zero
+
             if (.not. constituents(ivar)%simulate) cycle
 
             ! recalculate concentration for reservoirs

--- a/dsm2/src/gtm/boundary_advection_network.f90
+++ b/dsm2/src/gtm/boundary_advection_network.f90
@@ -764,8 +764,7 @@ module boundary_advection_network
     subroutine assign_boundary_concentration(conc_lo,  &
                                              conc_hi,  &
                                              ncell,    &
-                                             nvar,     &
-                                             tstp)
+                                             nvar)
         use constants
         use error_handling
         use gtm_vars, only: n_node, dsm2_network, dsm2_network_extra, n_bfbs, bfbs, &
@@ -775,7 +774,6 @@ module boundary_advection_network
         implicit none
         integer, intent(in)  :: ncell                            !< Number of cells
         integer, intent(in)  :: nvar                             !< Number of variables
-        integer, intent(in)  :: tstp
         real(gtm_real), intent(inout) :: conc_lo(ncell,nvar)     !< Concentration extrapolated to lo face
         real(gtm_real), intent(inout) :: conc_hi(ncell,nvar)     !< Concentration extrapolated to hi face
         integer :: i, j, k, s, st, icell, inode, qext_id, sed_id

--- a/dsm2/src/gtm/boundary_advection_network.f90
+++ b/dsm2/src/gtm/boundary_advection_network.f90
@@ -621,23 +621,13 @@ module boundary_advection_network
 
         use constants
         use state_variables_network, only: tran_flow
-        use gtm_vars, only : n_node, dsm2_network, n_tran, tran
+        use gtm_vars, only : n_node, dsm2_network, n_tran, tran, receiving_nodes, source_nodes
         implicit none
         integer,intent(in)  :: nvar                             !< Number of variables
         integer,intent(in)  :: ivar                             !< variable index
         real(gtm_real) :: flow_tmp(n_node),flux_in(n_node)
         real(gtm_real) :: conc_tmp(n_node, nvar)
         integer :: i,j,receiving_node,source_node
-        integer :: receiving_nodes(n_tran),source_nodes(n_tran)
-
-        ! identify nodes that are involved in transfer flows
-        ! TO DO: This needs to be moved to program initialization, before time loop.
-        if (n_tran > 0) then
-            do j = 1, n_tran
-                receiving_nodes(j) = tran(j)%to_identifier_int
-                source_nodes(j) = tran(j)%from_identifier_int
-            end do
-        end if
 
         ! compute concentration at all junctions except for nodes that reveive transfer flows
         do i = 1, n_node

--- a/dsm2/src/gtm_core/gtm_vars.f90
+++ b/dsm2/src/gtm_core/gtm_vars.f90
@@ -67,6 +67,8 @@ module gtm_vars
      logical :: run_mercury = .false.                  !< run mercury module if true
      logical :: run_pdaf = .false.                     !< run mercury module if true
      integer :: mercury_start_ivar = 0                 !< starting ivar index for mercury constituents
+     integer, allocatable :: receiving_nodes(:)        !< nodes receiving transfer flows
+     integer, allocatable :: source_nodes(:)           !< nodes sending transfer flows
 
      character*14 :: hdf_out                            ! hdf output resolution ('channel' or 'cell')
      character*14 :: dss_out = 'exact'                  !< dss output type ('cell' or 'exact')

--- a/dsm2/src/gtm_core/hdf_util.f90
+++ b/dsm2/src/gtm_core/hdf_util.f90
@@ -620,7 +620,7 @@ contains
 
    !> Read transfer flow tables from hydro tidefile to fill in transfer flow
    subroutine read_tran_tbl()
-       use gtm_vars, only : n_tran, tran, allocate_tran_property
+       use gtm_vars, only : n_tran, tran, allocate_tran_property, receiving_nodes, source_nodes
        implicit none
        integer(HID_T) :: input_id                       ! Group identifier
        integer(HID_T) :: dset_id                        ! Dataset identifier
@@ -632,7 +632,7 @@ contains
        integer(SIZE_T) :: typesize                      ! Size of the datatype
        integer(SIZE_T) :: type_size                     ! Size of the datatype
        integer :: hdferr                                 ! Error flag
-       integer :: i                                     ! local variables
+       integer :: i,j                                     ! local variables
        character*32, allocatable :: to_obj(:), from_obj(:)     ! local variables
 
        call h5gopen_f(hydro_id, "input", input_id, hdferr)
@@ -643,6 +643,8 @@ contains
        if (n_tran > 0) then
            allocate(to_obj(n_tran))
            allocate(from_obj(n_tran))
+           allocate(receiving_nodes(n_tran))
+           allocate(source_nodes(n_tran))
            call h5tcopy_f(H5T_NATIVE_CHARACTER, dt_id, hdferr)
            typesize = 32  ! the first column is charater, use typesize 32 to avoid reading errors.
            call h5tset_size_f(dt_id, typesize, hdferr)
@@ -685,8 +687,19 @@ contains
                if ((trim((to_obj(i)))) .eq. 'Reservoir') then !need to conver to upper case by using upcase()
                    tran(i)%to_obj = 3
                 end if
+                receiving_nodes(i) = tran(i)%to_identifier_int
+                source_nodes(i) = tran(i)%from_identifier_int
            end do
 
+           ! A node can only receive OR send transfer flow, but not both.
+           do i = 1, n_tran
+                do j = 1, n_tran
+                    if (receiving_nodes(i) == source_nodes(j)) then
+                        print *, "Error: Node ", receiving_nodes(i), " is both receiving and sending transfer flow. Please check transfer flow table in the input file."
+                        stop
+                    end if
+                end do
+            end do
            call h5tclose_f(dt5_id, hdferr)
            call h5tclose_f(dt4_id, hdferr)
            call h5tclose_f(dt3_id, hdferr)

--- a/dsm2/src/transport/advection.f90
+++ b/dsm2/src/transport/advection.f90
@@ -213,8 +213,7 @@ module advection
             call boundary_conc(conc_lo,              &
                                conc_hi,              &
                                ncell,                &
-                               nvar,                 &
-                               tstp)
+                               nvar)
         end if
         ! Compute upwind value of fluxes. This is a naive guess based on the extrapolated states
         ! It doesn't include any node-based sources or reservoirs or the like.

--- a/dsm2/src/transport/boundary_concentration.f90
+++ b/dsm2/src/transport/boundary_concentration.f90
@@ -28,14 +28,12 @@ module boundary_concentration
         subroutine boundary_concentration_if(conc_lo,    &
                                              conc_hi,    &
                                              ncell,      &
-                                             nvar,       &
-                                             tstp)
+                                             nvar)
             use constants
             implicit none
             !--- args
             integer, intent(in)  :: ncell                            !< Number of cells
             integer, intent(in)  :: nvar                             !< Number of variables
-            integer,intent(in)  :: tstp
             real(gtm_real), intent(inout) :: conc_lo(ncell,nvar)     !< Concentration extrapolated to lo face
             real(gtm_real), intent(inout) :: conc_hi(ncell,nvar)     !< Concentration extrapolated to hi face
 


### PR DESCRIPTION
## Summary
Fix summation bug for concentration and clean up transfer-related implementations

## Changes
- Initialize summation variable for each variable
- Move transfer-related initialization out of the time loop.

## Why
- The same variable was used across different variables for summation, leading to incorrect value when nvar > 1
- Same implementation was being repeated for every time step, when it only needs to be done only once.

## Testing
- Tested with regression tests